### PR TITLE
Add Teachng.com to Learning Websites

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -245,6 +245,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Quizlet](https://quizlet.com/latest)
 - [Ray Wenderlich](https://www.raywenderlich.com/)
 - [Silicon valley dictionary](http://svdictionary.com/) - Online dictionary targeted at Coders, similar to UrbanDictionary
+- [Teachng](https://teachng.com/) - Online Edcuation and Learning For Educators
 - [TED](https://www.ted.com/) - Free Expert Academic Talks.
 - [Tutorials point](https://www.tutorialspoint.com/index.htm) - Online Tutorials at your own pace.
 - [Udacity](https://www.udacity.com/)


### PR DESCRIPTION
Teachng.com is a website created by educators for educators. Offering insights from top industry experts, it offers educators a place to learn and grow professionally.