### PR TITLE
Add SpicyChai LaTeX to websites list

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -389,6 +389,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Regexr](http://regexr.com/) - Online tool to learn, build, & test Regular Expressions (RegEx / RegExp).
 - [Regulex](https://jex.im/regulex/) - Regular Expression Visualizer.
 - [ShareLaTeX](https://www.sharelatex.com) - Online LaTeX editing.
+- [SpicyChai LaTeX](https://latex.spicychai.com/) - Online LaTeX editor with AI-powered templates and real-time PDF preview.
 - [Sketch toy](http://sketchtoy.com/) - Free online drawing application that lets you share step-by-step replays of your work.
 - [Sleep time](http://sleepyti.me/) - An online tool that can help you maximize your quality of sleep by hacking your sleep cycle.
 - [Symbolab](https://www.symbolab.com/) - Online calculator that can do Calculus.


### PR DESCRIPTION
## Summary

Adds [SpicyChai LaTeX](https://latex.spicychai.com/) alongside the existing Overleaf and ShareLaTeX entries in the Tools section.

SpicyChai LaTeX is an online LaTeX editor and compiler featuring:
- AI-powered template population
- Real-time PDF preview
- Free anonymous renders without signup

**Disclosure:** I am the creator of SpicyChai LaTeX.